### PR TITLE
BaseModel properties virtual in order to override them and Dates in UTC

### DIFF
--- a/pocketbase-csharp-sdk/Json/DateTimeConverter.cs
+++ b/pocketbase-csharp-sdk/Json/DateTimeConverter.cs
@@ -15,11 +15,11 @@ namespace pocketbase_csharp_sdk.Json
         public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             var value = reader.GetString();
-            if (DateTime.TryParse(value, out var dt))
-            {
-                return dt;
-            }
-            return null;
+            if (!DateTime.TryParse(value, out var dt))
+                return null;
+
+            DateTime.SpecifyKind(dt, DateTimeKind.Utc);
+            return dt;
         }
 
         public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options)

--- a/pocketbase-csharp-sdk/Models/BaseModel.cs
+++ b/pocketbase-csharp-sdk/Models/BaseModel.cs
@@ -10,15 +10,21 @@ namespace pocketbase_csharp_sdk.Models
 {
     public abstract class BaseModel
     {
-        public string? Id { get; set; }
+        [JsonPropertyName("id")]
+        public virtual string? Id { get; set; }
 
+        [JsonPropertyName("created")]
         [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime? Created { get; set; }
+        public virtual DateTime? Created { get; set; }
 
+        [JsonPropertyName("updated")]
         [JsonConverter(typeof(DateTimeConverter))]
-        public DateTime? Updated { get; set; }
+        public virtual DateTime? Updated { get; set; }
 
-        public string? CollectionId { get; set; }
-        public string? CollectionName { get; set; }
+        [JsonPropertyName("collectionId")]
+        public virtual string? CollectionId { get; set; }
+
+        [JsonPropertyName("collectionName")]
+        public virtual string? CollectionName { get; set; }
     }
 }


### PR DESCRIPTION
I'm developing the Code Generator in my project: for mapping an item to an object I generate a class that inherits from BaseModel.
But it is interesting to make the properties overridables (virtual) in order to create specific logic in getters or setters.
Also, dates in Pocketbase are in UTC, I specified this information in c# when reads from json