### PR TITLE
Download file using new PocketBase function GetStreamAsync

### DIFF
--- a/pocketbase-csharp-sdk/PocketBase.cs
+++ b/pocketbase-csharp-sdk/PocketBase.cs
@@ -1,4 +1,5 @@
-﻿using pocketbase_csharp_sdk.Event;
+﻿using pocketbase_csharp_sdk.Enum;
+using pocketbase_csharp_sdk.Event;
 using pocketbase_csharp_sdk.Json;
 using pocketbase_csharp_sdk.Models;
 using pocketbase_csharp_sdk.Models.Files;
@@ -150,6 +151,33 @@ namespace pocketbase_csharp_sdk
                 }
 
                 return await response.Content.ReadFromJsonAsync<T>();
+            }
+            catch (Exception ex)
+            {
+                if (ex is ClientException)
+                {
+                    throw;
+                }
+                else if (ex is HttpRequestException)
+                {
+                    throw new ClientException(url: url.ToString(), originalError: ex, isAbort: true);
+                }
+                else
+                {
+                    throw new ClientException(url: url.ToString(), originalError: ex);
+                }
+            }
+        }
+
+        public async Task<Stream> GetStreamAsync(string path, IDictionary<string, object?>? query = null, CancellationToken cancellationToken = default)
+        {
+            query ??= new Dictionary<string, object?>();
+            
+            Uri url = BuildUrl(path, query);
+
+            try
+            {
+                return await _httpClient.GetStreamAsync(url, cancellationToken);
             }
             catch (Exception ex)
             {

--- a/pocketbase-csharp-sdk/Services/RecordService.cs
+++ b/pocketbase-csharp-sdk/Services/RecordService.cs
@@ -2,6 +2,7 @@
 using pocketbase_csharp_sdk.Models;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -31,16 +32,17 @@ namespace pocketbase_csharp_sdk.Services
             return client.BuildUrl(url, query);
         }
 
-        public Task<Stream> DownloadFileAsync(string sub, string recordId, string fileName, ThumbFormat? thumbFormat = null, CancellationToken cancellationToken = default)
+        public async Task<Stream> DownloadFileAsync(string collectionId, string recordId, string fileName, ThumbFormat? thumbFormat = null, CancellationToken cancellationToken = default)
         {
+            var url = $"api/files/{UrlEncode(collectionId)}/{UrlEncode(recordId)}/{fileName}";
+
             //TODO find out how the specify the actual resolution to resize
             var query = new Dictionary<string, object?>() 
             {
                 { "thumb", ThumbFormatHelper.GetNameForQuery(thumbFormat) }
             };
             
-            var fileUrl = GetFileUrl(sub, recordId, fileName, query);
-            return client._httpClient.GetStreamAsync(fileUrl, cancellationToken);
+            return await client.GetStreamAsync(url, query, cancellationToken);
         }
         
     }


### PR DESCRIPTION
Changes:
1- New function in PocketBase class: `GetStreamAsync` 
2- In `RecordService` there is no direct call to _httpClient 
3- `RecordService.DownloadFileAsync` async and parameter renaming